### PR TITLE
Release cockroachdb 2.0.1-2.0.1 (automated commit)



### DIFF
--- a/repo/packages/C/cockroachdb/5/config.json
+++ b/repo/packages/C/cockroachdb/5/config.json
@@ -1,0 +1,176 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "cockroachdb"
+        },
+        "user": {
+          "title": "User",
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "cache_size": {
+          "title": "CockroachDB cache size",
+          "description": "Cache size to be used by CockroachDB",
+          "type": "string",
+          "default": "25%"
+        },
+        "max_sql_memory": {
+          "title": "CockroachDB max SQL memory",
+          "description": "Maximum amount of memory for CockroachDB to use for processing SQL queries",
+          "type": "string",
+          "default": "25%"
+        },
+        "http_port": {
+          "title": "CockroachDB HTTP Port",
+          "description": "Port for CockroachDB admin UI",
+          "type": "number",
+          "default": 80
+        },
+        "pg_port": {
+          "title": "CockroachDB PG Port",
+          "description": "Port for CockroachDB client communication",
+          "type": "number",
+          "default": 26257
+        },
+        "container_http_port": {
+          "title": "Container HTTP Port",
+          "description": "Container port for CockroachDB admin UI. This port MUST be available on the host machine.",
+          "type": "number",
+          "default": 8123
+        },
+        "container_pg_port": {
+          "title": "Container PG Port",
+          "description": "Container port for CockroachDB client communication. This port MUST be available on the host machine.",
+          "type": "number",
+          "default": 26257
+        },
+        "virtual_network": {
+          "description": "Enable DC/OS Virtual Network",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "name",
+        "user"
+      ]
+    },
+    "node": {
+      "description": "Template pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of Template pods to run",
+          "type": "integer",
+          "default": 3
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": "hostname:UNIQUE"
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Template pod CPU requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Template pod mem requirements (in MB)",
+          "type": "integer",
+          "default": 3000
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Template pod persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 5000
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type"
+      ]
+    },
+    "side": {
+      "description": "Template pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of Template pods to run",
+          "type": "integer",
+          "default": 1
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Template pod CPU requirements",
+          "type": "number",
+          "default": 1
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Template pod mem requirements (in MB)",
+          "type": "integer",
+          "default": 1000
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Template pod persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 5000
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type"
+      ]
+    }
+  }
+}

--- a/repo/packages/C/cockroachdb/5/marathon.json.mustache
+++ b/repo/packages/C/cockroachdb/5/marathon.json.mustache
@@ -1,0 +1,100 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./cockroachdb-scheduler/bin/cockroachdb ./cockroachdb-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "CONFIG_TEMPLATE_PATH": "cockroachdb-scheduler",
+
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "COCKROACH_URI": "{{resource.assets.uris.cockroach-tgz}}",
+    "COCKROACH_DIR": "cockroach-v2.0.1.linux-amd64",
+    "COCKROACH_CACHE_SIZE": "{{service.cache_size}}",
+    "COCKROACH_MAX_SQL_MEMORY": "{{service.max_sql_memory}}",
+    "COCKROACH_HTTP_PORT": "{{service.http_port}}",
+    "COCKROACH_PG_PORT": "{{service.pg_port}}",
+    "CONTAINER_HTTP_PORT": "{{service.container_http_port}}",
+    "CONTAINER_PG_PORT": "{{service.container_pg_port}}",
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_PLACEMENT": "{{node.placement_constraint}}",
+    {{#service.virtual_network}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    {{/service.virtual_network}}
+    "NODE_CPUS": "{{node.cpus}}",
+    "NODE_MEM": "{{node.mem}}",
+    "NODE_DISK": "{{node.disk}}",
+    "NODE_DISK_TYPE": "{{node.disk_type}}",
+    "SIDE_COUNT": "{{side.count}}",
+    "SIDE_CPUS": "{{side.cpus}}",
+    "SIDE_MEM": "{{side.mem}}",
+    "SIDE_DISK": "{{side.disk}}",
+    "SIDE_DISK_TYPE": "{{side.disk_type}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.service_account_secret}}
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/C/cockroachdb/5/package.json
+++ b/repo/packages/C/cockroachdb/5/package.json
@@ -1,0 +1,18 @@
+{
+    "packagingVersion": "4.0",
+    "minDcosReleaseVersion": "1.9",
+    "name": "cockroachdb",
+    "version": "2.0.1-2.0.1",
+    "maintainer": "support@cockroachlabs.com",
+    "description": "CockroachDB is a distributed relational database that is scalable, survivable, and strongly consistent. Service Guide is available at: https://github.com/cockroachdb/dcos-cockroachdb-service The source code for CockroachDB Enterprise is packaged in the same binary as CockroachDB Core.\n\n\tCustomers interested in the CockroachDB Enterprise license should contact https://www.cockroachlabs.com/pricing/sales/",
+    "selected": false,
+    "framework": true,
+    "tags": [
+        "cockroachdb",
+        "sql",
+        "database"
+    ],
+    "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production! For a replicated cluster, please use at least 3 nodes to ensure availability with 1 CPU and 2 GB of RAM per node.",
+    "postInstallNotes": "CockroachDB is being installed!\n\n\tDocumentation: https://www.cockroachlabs.com/docs\n\tIssues: contact https://www.cockroachlabs.com/docs/support-resources.html\n\tRelease Notes: https://www.cockroachlabs.com/docs/releases/v2.0.1.html",
+    "postUninstallNotes": "CockroachDB has been uninstalled."
+}

--- a/repo/packages/C/cockroachdb/5/resource.json
+++ b/repo/packages/C/cockroachdb/5/resource.json
@@ -1,0 +1,57 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u152-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
+      "scheduler-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/cockroachdb-scheduler.zip",
+      "executor-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/executor.zip",
+      "bootstrap-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/bootstrap.zip",
+      "cockroach-tgz": "https://binaries.cockroachdb.com/cockroach-v2.0.1.linux-amd64.tgz"
+    }
+  },
+  "images": {
+    "icon-small": "http://i.imgur.com/FsEREZI.png",
+    "icon-medium": "http://i.imgur.com/1DvX5di.png?1",
+    "icon-large": "http://i.imgur.com/P1mjjGK.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "c8c10cb1757e8c431c53e10896621775a81cfaa89bcc6be1da6ad927eb99fd66"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "91851ee4f87e4e93e402fb470909b33d9cb9160e65cabc8a86982308594f94d4"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "c44b6415a0d7466538daef0fd811ccb93a0e145c63800121ef01806a1f1f974a"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release cockroachdb 2.0.1-2.0.1 (automated commit)

Description:
Fix symlink path issue in most recent CockroachDB framework release

Source URL: https://alex-dcos-exhibitors3bucket-gx95x7buf8qx.s3.amazonaws.com/autodelete7d/cockroachdb/20180516-171107-Ue3WAndhIJGUcj2D/stub-universe-cockroachdb.json

Changes since revision 4:
0 files added: []
0 files removed: []
3 files changed:

```
--- 4/marathon.json.mustache
+++ 5/marathon.json.mustache
@@ -27,6 +27,7 @@
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
     "COCKROACH_URI": "{{resource.assets.uris.cockroach-tgz}}",
+    "COCKROACH_DIR": "cockroach-v2.0.1.linux-amd64",
     "COCKROACH_CACHE_SIZE": "{{service.cache_size}}",
     "COCKROACH_MAX_SQL_MEMORY": "{{service.max_sql_memory}}",
     "COCKROACH_HTTP_PORT": "{{service.http_port}}",
--- 4/package.json
+++ 5/package.json
@@ -2,7 +2,7 @@
     "packagingVersion": "4.0",
     "minDcosReleaseVersion": "1.9",
     "name": "cockroachdb",
-    "version": "2.0.0-2.0.1",
+    "version": "2.0.1-2.0.1",
     "maintainer": "support@cockroachlabs.com",
     "description": "CockroachDB is a distributed relational database that is scalable, survivable, and strongly consistent. Service Guide is available at: https://github.com/cockroachdb/dcos-cockroachdb-service The source code for CockroachDB Enterprise is packaged in the same binary as CockroachDB Core.\n\n\tCustomers interested in the CockroachDB Enterprise license should contact https://www.cockroachlabs.com/pricing/sales/",
     "selected": false,
--- 4/resource.json
+++ 5/resource.json
@@ -3,9 +3,9 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u152-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
-      "scheduler-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.1/cockroachdb-scheduler.zip",
-      "executor-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.1/executor.zip",
-      "bootstrap-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.1/bootstrap.zip",
+      "scheduler-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/cockroachdb-scheduler.zip",
+      "executor-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/executor.zip",
+      "bootstrap-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/bootstrap.zip",
       "cockroach-tgz": "https://binaries.cockroachdb.com/cockroach-v2.0.1.linux-amd64.tgz"
     }
   },
@@ -25,7 +25,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.1/dcos-service-cli-darwin"
+          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -37,7 +37,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.1/dcos-service-cli-linux"
+          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -49,7 +49,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.1/dcos-service-cli.exe"
+          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.1-2.0.1/dcos-service-cli.exe"
         }
       }
     }
```
